### PR TITLE
Update to gitignore attributes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,10 @@ coinswap-kotlin/src/main/kotlin/uniffi/
 coinswap-kotlin/src/main/resources/
 coinswap-kotlin/local.properties
 coinswap-swift/libcoinswap_ffi.so
+coinswap-swift/Coinswap.swift
+coinswap-swift/coinswap.swift
+coinswap-swift/CoinswapFFI.modulemap
+coinswap-swift/coinswapFFI.modulemap
 coinswap-ruby/libcoinswap_ffi.so
 coinswap-python/uniffi-bindgen
 coinswap-kotlin/uniffi-bindgen


### PR DESCRIPTION
On MacOS, the lowercase and uppercase labelling of coinswap.swift libs and modulemaps create zombie changes across the changeset while interacting with version history and git. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated repository build configuration to properly manage generated build artifacts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->