### PR TITLE
Cargo updates for branch seperation for segregated apis vs unified

### DIFF
--- a/coinswap-js/Cargo.toml
+++ b/coinswap-js/Cargo.toml
@@ -11,7 +11,7 @@ crate-type = ["cdylib"]
 [dependencies]
 napi = "3.0.0"
 napi-derive = "3.0.0"
-coinswap = { git = "https://github.com/citadel-tech/coinswap.git", branch = "master" }
+coinswap = { git = "https://github.com/citadel-tech/coinswap.git", rev = "90c9a02c3ecd4464b59140119a94c5ad867d184a" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 hex = "0.4"

--- a/ffi-commons/Cargo.toml
+++ b/ffi-commons/Cargo.toml
@@ -16,7 +16,7 @@ path = "uniffi-bindgen.rs"
 
 [dependencies]
 uniffi = { version = "0.30.0", features = [ "cli" ] }
-coinswap = { git = "https://github.com/citadel-tech/coinswap.git", branch = "master" }
+coinswap = { git = "https://github.com/citadel-tech/coinswap.git", rev = "90c9a02c3ecd4464b59140119a94c5ad867d184a" }
 thiserror = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"


### PR DESCRIPTION
Setting the branch to offerbook-fix [commit](https://github.com/citadel-tech/coinswap/commit/90c9a02c3ecd4464b59140119a94c5ad867d184a) so all downstream apps and wallets don't break atp.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal dependencies to use pinned versions for improved stability and consistency in builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->